### PR TITLE
chore: update logo URLs in email templates

### DIFF
--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/add-deal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/add-deal.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/add-lead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/add-lead.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addDeal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addDeal.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addLead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addLead.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addSelfDeal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addSelfDeal.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addSelfLead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addSelfLead.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approval-privileges-updated-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approval-privileges-updated-notification.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approval-reminder-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approval-reminder-notification.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approve-or-reject-dam-content.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approve-or-reject-dam-content.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approve-or-reject-lead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approve-or-reject-lead.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/asset-shared-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/asset-shared-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/asset-shared-vendor-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/asset-shared-vendor-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/assets-shared-to-newly-added-partners-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/assets-shared-to-newly-added-partners-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/campaign-mdf-account-request.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/campaign-mdf-account-request.html
@@ -34,7 +34,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="No Image Found" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/dashboard-buttons-shared-with-sso-partner-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/dashboard-buttons-shared-with-sso-partner-notification.html
@@ -33,7 +33,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="No Logo" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/demo-request.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/demo-request.html
@@ -34,7 +34,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="No Image Found" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/download-csv.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/download-csv.html
@@ -20,8 +20,8 @@
 											<tr>
 												<td align="center" style="padding: 46px 0 0 0;"><a
 													href="javascript:void(0)" target="_blank"> <img
-														src="https://xamplify.io/assets/images/xamplify-logo.png"
-														alt="https://xamplify.io/assets/images/xamplify-logo.png"
+														src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
+														alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 														width="145" align="center"/>
 												</a></td>
 											</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/draft-campaign-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/draft-campaign-notification.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
         </td>
         </tr>
         <tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/form-leads-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/form-leads-notification.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
         </td>
         </tr>
         <tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/integration-expired.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/integration-expired.html
@@ -33,8 +33,8 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${loginUrl}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
-						alt="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
+						alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead-list-in-process-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead-list-in-process-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead-list-processed-not-shared-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead-list-processed-not-shared-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead-list-processed-shared-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead-list-processed-shared-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead-list-shared-to-partner.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead-list-shared-to-partner.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead-list-updated-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead-list-updated-notification.html
@@ -16,7 +16,7 @@
           <table width="100%" cellpadding="0" cellspacing="0" border="0"> 
            <tbody style="background-color: white !important">
             <tr> 
-             <td align="center" style="padding:10px 0 0 0;"> <a th:href="${targetURL}"  target="_blank"> <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="" width="145" align="center"/> </a> </td> 
+             <td align="center" style="padding:10px 0 0 0;"> <a th:href="${targetURL}"  target="_blank"> <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="" width="145" align="center"/> </a> </td> 
             </tr> 
             <tr> 
              <td style="font-family:Century Gothic;font-size:14px;line-height:36px;padding:20px 90px 10px 90px;"> Hi <span th:text="${welcomeDisplayName}"></span>, </td> 

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead_list_delete_message.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead_list_delete_message.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead_list_delete_message_for_saved_campaigns.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead_list_delete_message_for_saved_campaigns.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead_list_delete_message_for_scheduled_campaigns.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/lead_list_delete_message_for_scheduled_campaigns.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/link-clicked-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/link-clicked-notification.html
@@ -17,7 +17,7 @@ font-family:Century Gothic;font-size:14px
         <tr>
         <td align="center">
             <a th:href="${loginUrl}" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/marketing-role-upgraded-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/marketing-role-upgraded-notification.html
@@ -33,7 +33,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="No Logo" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-fund-partner-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-fund-partner-notification.html
@@ -40,7 +40,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-fund-vendor-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-fund-vendor-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-request-document-uploaded-partner-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-request-document-uploaded-partner-notification.html
@@ -31,7 +31,7 @@
             <tr>
                <td align="center"><a th:href="${targetURL}"
                   target="_blank"> <img
-                  src="https://xamplify.io/assets/images/xamplify-logo.png"
+                  src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
                   alt=""
                   width="145" align="center" />
                   </a>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-request-document-uploaded-vendor-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-request-document-uploaded-vendor-notification.html
@@ -31,7 +31,7 @@
             <tr>
                <td align="center"><a th:href="${targetURL}"
                   target="_blank"> <img
-                  src="https://xamplify.io/assets/images/xamplify-logo.png"
+                  src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
                   alt=""
                   width="145" align="center" />
                   </a>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-request-status-partner-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-request-status-partner-notification.html
@@ -31,7 +31,7 @@
             <tr>
                <td align="center"><a th:href="${targetURL}"
                   target="_blank"> <img
-                  src="https://xamplify.io/assets/images/xamplify-logo.png"
+                  src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
                   alt=""
                   width="145" align="center" />
                   </a>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-request-status-vendor-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/mdf-request-status-vendor-notification.html
@@ -31,7 +31,7 @@
             <tr>
                <td align="center"><a th:href="${targetURL}"
                   target="_blank"> <img
-                  src="https://xamplify.io/assets/images/xamplify-logo.png"
+                  src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
                   alt=""
                   width="145" align="center" />
                   </a>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/microsoft-config-issue-vendor.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/microsoft-config-issue-vendor.html
@@ -33,8 +33,8 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${loginUrl}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
-						alt="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
+						alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/new-mdf-request-partner-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/new-mdf-request-partner-notification.html
@@ -31,7 +31,7 @@
             <tr>
                <td align="center"><a th:href="${targetURL}"
                   target="_blank"> <img
-                  src="https://xamplify.io/assets/images/xamplify-logo.png"
+                  src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
                   alt=""
                   width="145" align="center" />
                   </a>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/new-mdf-request-vendor-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/new-mdf-request-vendor-notification.html
@@ -32,7 +32,7 @@
             <tr>
                <td align="center"><a th:href="${targetURL}"
                   target="_blank"> <img
-                  src="https://xamplify.io/assets/images/xamplify-logo.png"
+                  src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
                   alt=""
                   width="145" align="center" />
                   </a>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/one-click-launch-save-campaigns-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/one-click-launch-save-campaigns-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/one-click-launch-schedule-campaigns-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/one-click-launch-schedule-campaigns-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/page-campaign-to-contacts.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/page-campaign-to-contacts.html
@@ -18,7 +18,7 @@ font-family:Century Gothic;font-size:14px
         <tr>
         <td align="center">
             <a th:href="${loginUrl}" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/prmAddLead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/prmAddLead.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/prmUpdateLead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/prmUpdateLead.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/processing-user-lists-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/processing-user-lists-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/publish-learning-track-vendor.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/publish-learning-track-vendor.html
@@ -33,8 +33,8 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${loginUrl}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
-						alt="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
+						alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/refer-a-vendor-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/refer-a-vendor-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/sf-expired-vendor.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/sf-expired-vendor.html
@@ -33,8 +33,8 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${loginUrl}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
-						alt="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
+						alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/sso-published-content-details.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/sso-published-content-details.html
@@ -33,7 +33,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="No Logo" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/superadmin-user-welcome.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/superadmin-user-welcome.html
@@ -35,8 +35,8 @@ td {
 			<tr>
 				<td align="center"><a href="javascript:void(0)"
 					target="_blank"> <img
-						src="https://xamplify.io/assets/images/xamplify-logo.png"
-						alt="https://xamplify.io/assets/images/xamplify-logo.png"
+						src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
+						alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-added-email-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-added-email-notification.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-complete-email-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-complete-email-notification.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-overdue-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-overdue-notification.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-remainder-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-remainder-notification.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/track-or-playbook-shared-vendor-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/track-or-playbook-shared-vendor-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/update-deal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/update-deal.html
@@ -14,7 +14,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateDeal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateDeal.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateLead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateLead.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateSelfDeal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateSelfDeal.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a href="javascript:void(0)" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateSelfLead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateSelfLead.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/upgrading-account-email-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/upgrading-account-email-notification.html
@@ -33,7 +33,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="No Logo" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/upgrading-to-marketing-role-request.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/upgrading-to-marketing-role-request.html
@@ -16,7 +16,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
         <tr>
         <td align="center">
             <a th:href="${targetURL}" target="_blank"> 
-            <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="No Logo" width="145" align="center"/>
+            <img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png" alt="No Logo" width="145" align="center"/>
             </a>
         </td>
         </tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/upload-asset-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/upload-asset-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/vendor-journey-shared-pages-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/vendor-journey-shared-pages-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/vendor-landing-page-partner-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/vendor-landing-page-partner-notification.html
@@ -41,7 +41,7 @@ td {
 		<tbody>
 			<tr>
 				<td align="center"><a th:href="${targetURL}" target="_blank">
-						<img src="https://xamplify.io/assets/images/xamplify-logo.png"
+						<img src="https://raw.githubusercontent.com/xamplify/xAmplify-prm-core/main/docs/images/xamplify-logo.png"
 						alt="" width="145" align="center" />
 				</a></td>
 			</tr>


### PR DESCRIPTION
## Summary
- update email template logo references to the GitHub-hosted asset so all messages use the latest image
- ensure both `src` and duplicated `alt` attributes point to the new logo URL

## Testing
- mvn -f xamplify-prm/pom.xml -pl xamplify-prm-api test *(fails: Non-resolvable import POM due to blocked mirrors in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c861403ebc8328ad2a40ab95f42930