### PR TITLE
Replace javascript:void(0) anchors in HTML templates

### DIFF
--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/add-deal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/add-deal.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/add-lead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/add-lead.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addDeal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addDeal.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addLead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addLead.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addSelfDeal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addSelfDeal.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addSelfLead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/addSelfLead.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approval-privileges-updated-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approval-privileges-updated-notification.html
@@ -14,7 +14,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approval-reminder-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approval-reminder-notification.html
@@ -14,7 +14,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approve-or-reject-dam-content.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approve-or-reject-dam-content.html
@@ -14,7 +14,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approve-or-reject-lead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/approve-or-reject-lead.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/download-csv.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/download-csv.html
@@ -19,7 +19,7 @@
 										<tbody>
 											<tr>
 												<td align="center" style="padding: 46px 0 0 0;"><a
-													href="javascript:void(0)" target="_blank"> <img
+													href="#" target="_blank"> <img
 														src="https://xamplify.io/assets/images/xamplify-logo.png"
 														alt="https://xamplify.io/assets/images/xamplify-logo.png"
 														width="145" align="center"/>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/prmAddLead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/prmAddLead.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/prmUpdateLead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/prmUpdateLead.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/social-campaign.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/social-campaign.html
@@ -17,7 +17,7 @@ hr{margin:20px;border:1px solid #f1f1f1}
 <div style="background-color: #fafafa">
 	<table align="center">
 		<tr><td align="center" style="padding: 2em;">
-		<a href="javascript:void(0)">
+		<a href="#">
 		<img th:src="${companyLogo}" height="80"/></a></td></tr>
 		<tr>
 			<td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/social-media-campaign-failed-email-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/social-media-campaign-failed-email-notification.html
@@ -48,7 +48,7 @@ hr {
 		<table align="center">
 			<tr>
 				<td align="center" style="padding: 2em;"><a
-					href="javascript:void(0)"> <img th:src="${companyLogo}"
+					href="#"> <img th:src="${companyLogo}"
 						height="80" /></a></td>
 			</tr>
 			<tr>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/superadmin-user-welcome.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/superadmin-user-welcome.html
@@ -33,7 +33,7 @@ td {
 	<table align="center">
 		<tbody>
 			<tr>
-				<td align="center"><a href="javascript:void(0)"
+				<td align="center"><a href="#"
 					target="_blank"> <img
 						src="https://xamplify.io/assets/images/xamplify-logo.png"
 						alt="https://xamplify.io/assets/images/xamplify-logo.png"

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-added-email-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-added-email-notification.html
@@ -14,7 +14,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-complete-email-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-complete-email-notification.html
@@ -14,7 +14,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-overdue-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-overdue-notification.html
@@ -14,7 +14,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-remainder-notification.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/task-remainder-notification.html
@@ -14,7 +14,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/update-deal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/update-deal.html
@@ -13,7 +13,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateDeal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateDeal.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateLead.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateLead.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>

--- a/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateSelfDeal.html
+++ b/xamplify-prm/xamplify-prm-api/src/main/resources/templates/updateSelfDeal.html
@@ -15,7 +15,7 @@ td{font-size: 13px; line-height: 24px; padding: 15px 40px}
     <tbody>
         <tr>
         <td align="center">
-            <a href="javascript:void(0)" target="_blank"> 
+            <a href="#" target="_blank"> 
             <img src="https://xamplify.io/assets/images/xamplify-logo.png" alt="https://xamplify.io/assets/images/xamplify-logo.png" width="145" align="center"/>
             </a>
         </td>


### PR DESCRIPTION
## Summary
- replace `javascript:void(0)` anchor hrefs with `#` across HTML email templates to avoid inline JavaScript usage

## Testing
- not run (html-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68c8f18639b88328bafd9b7d9688d474